### PR TITLE
explicitly cast map to string, otherwise sander confuses it with an o…

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function postcss ( inputdir, outputdir, options ) {
 				}).then( function ( result ) {
 					var promises = [ sander.writeFile( outputdir, dest, result.css ) ];
 					if ( map ) {
-						promises.push( sander.writeFile( outputdir, dest + '.map', result.map ) );
+						promises.push( sander.writeFile( outputdir, dest + '.map', String( result.map ) ) );
 					}
 					return Promise.all( promises );
 				});

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "prepublish": "npm test"
   },
   "dependencies": {
-    "glob": "^5.0.14",
-    "postcss": "^5.0.5",
-    "sander": "^0.3.5"
+    "glob": "^5.0.15",
+    "postcss": "^5.0.9",
+    "sander": "^0.3.8"
   }
 }


### PR DESCRIPTION
…ptions object

Could you please also release this. It currently breaks because of `[Error: EISDIR: illegal operation on a directory, open '.gobble/05-postcss/1']`
