### PR TITLE
Update dependencies to avoid graceful-fs related warnings on node 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "prepublish": "npm test"
   },
   "dependencies": {
-    "glob": "^5.0.15",
-    "postcss": "^5.0.9",
-    "sander": "^0.3.8"
+    "glob": "^7.0.3",
+    "postcss": "^5.0.21",
+    "sander": "^0.5.1"
   }
 }


### PR DESCRIPTION
Node 6.x warns about using graceful-fs 0.3.x which is a dependencies of sander 0.3.x
